### PR TITLE
fix underflow

### DIFF
--- a/src/deed.sol
+++ b/src/deed.sol
@@ -191,7 +191,7 @@ contract DSDeed is ERC721, ERC721Enumerable, ERC721Metadata {
         _allDeeds.push(nft);
         _deeds[nft] = Deed(
             _allDeeds[_allDeeds.length - 1],
-            _usrDeeds[guy].length - 1,
+            _usrDeeds[guy].length == 0 ? 0 : _usrDeeds[guy].length - 1,
             guy,
             address(0)
         );


### PR DESCRIPTION
Hi, when I changed pragma to 0.8.x, the code fails at compile time because of underflow in L194 during the first `mint`.

```
    ├─ [52444] DSDeed::mint(0x00000000219ab540356cbb839cbe05303d7705fa, "t1") 
    │   └─ ← "Arithmetic over/underflow"
    └─ ← "Arithmetic over/underflow"
```

The call to `_upush` fixes  `upos`, so data looks good to the caller.
I added a branch here so it will compile, should be good as a temporary fix.